### PR TITLE
ci: fix GitHub Workflow output method

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
           wkhtmltopdf --version
 
           echo build
-          (npm run pdf  && echo "::set-output name=pdf::$(ls *.pdf)")   || true
-          (npm run epub && echo "::set-output name=epub::$(ls *.epub)") || true
+          (npm run pdf  && echo "pdf=$(ls *.pdf)"   >> $GITHUB_OUTPUT) || true
+          (npm run epub && echo "epub=$(ls *.epub)" >> $GITHUB_OUTPUT) || true
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)


### PR DESCRIPTION
fix output

ref https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/