### PR TITLE
fix: libssl 1.1 download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,16 @@ jobs:
       - name: Setup wkhtmltopdf
         run: |
           echo from adrg/go-wkhtmltopdf workflow
+          echo Get deb file
           sudo apt-get update
-          sudo apt-get install -y xfonts-75dpi xfonts-base libssl1.1
+          sudo apt-get install -y xfonts-75dpi xfonts-base
           curl --silent --show-error --location --max-redirs 3 --fail --retry 3 --output wkhtmltopdf-linux-amd64.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
+          echo In Ubuntu 24.04, need archived libssl1.1
+          curl --silent --show-error --location --max-redirs 3 --fail --retry 3 --output libssl1.1-linux-amd64.deb http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.23_amd64.deb
+          sudo dpkg -i libssl1.1-linux-amd64.deb
           sudo dpkg -i wkhtmltopdf-linux-amd64.deb
           sudo ldconfig
-          rm wkhtmltopdf-linux-amd64.deb
+          rm *.deb
 
       - name: Setup calibre
         run: |


### PR DESCRIPTION
libssl1.1 は 24.04 は download して入れる

see https://github.com/dotnet/sdk/issues/24759